### PR TITLE
add Knife quest music, strange door jingle, fixed Greed Krampus

### DIFF
--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -829,8 +829,8 @@ MusicModCallback:AddCallback(ModCallbacks.MC_POST_RENDER, function()
 	local currentMusicId = musicmgr:GetCurrentMusicID()
 	local ispaused = Game():IsPaused()
 	
-	--play music even if pause instantly after starting game
-	if ispaused and (currentMusicId == Music.MUSIC_JINGLE_GAME_START or currentMusicId == Music.MUSIC_JINGLE_GAME_START_ALT) then
+	--play music even if pause within first 10 frames (except on frame zero)
+	if ispaused and room:GetFrameCount() > 0 and (currentMusicId == Music.MUSIC_JINGLE_GAME_START or currentMusicId == Music.MUSIC_JINGLE_GAME_START_ALT) then
 		currentMusicId = 0
 	end
 	


### PR DESCRIPTION
Using the special TargetRoomIndexes, play the reversed Downpour and Dross themes when in the mirrored world, and the mineshaft ambient and mineshaft escape music when in the mineshaft. The former works well, while the latter needs a few touch-ups (the correct music doesn't play when Mother's Shadow spawns, also the ambient track restarted upon entering the Knife Piece 2 room).

We leverage save data so that the correct music will play even upon closing the game and then continuing the run.