### PR TITLE
MusicJingles, SoundJingles, and Game Start

### DIFF
--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -842,7 +842,9 @@ MusicModCallback:AddCallback(ModCallbacks.MC_POST_GAME_STARTED, function() --thi
 		if room:GetType() == RoomType.ROOM_BOSS and not room:IsClear() then
 			musicJingles[currentMusicId]["nexttrack"] = getBossMusic()
 		else
+			waitingforgamestjingle = false --trick getMusicTrack into giving us the track early
 			musicJingles[currentMusicId]["nexttrack"] = getMusicTrack()
+			waitingforgamestjingle = true --Cyber: "This may not be good code, but I don't want to interfere with the check that Nato added to the beginning of getMusicTrack because I figure it is important for the Soundtrack Menu."
 		end
 	end
 end)

--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -300,10 +300,10 @@ soundJingles[Music.MUSIC_JINGLE_TREASUREROOM_ENTRY_2] = {
 soundJingles[Music.MUSIC_JINGLE_TREASUREROOM_ENTRY_3] = {
 	["id"] = 815, --once custom sounds are fixed, will be something like Isaac.GetSoundIdByName("Treasure Jingle 4")
 }
-soundJingles[Music.MUSIC_STRANGE_DOOR_JINGLE] = {
+soundJingles[Music.MUSIC_JINGLE_SECRETROOM_FIND] = {
 	["id"] = 0, --once custom sounds are fixed, will be something like Isaac.GetSoundIdByName("Secret Room Jingle")
 }
-soundJingles[Music.MUSIC_JINGLE_SECRETROOM_FIND] = {
+soundJingles[Music.MUSIC_STRANGE_DOOR_JINGLE] = {
 	["id"] = 0, --once custom sounds are fixed, will be something like Isaac.GetSoundIdByName("Strange Door Jingle")
 }
 --]]
@@ -631,7 +631,7 @@ function musicCrossfade(track, track2)
 		--but if a boss over jingle replaces a stage track, it is not considered a jingle
 		--IMPORTANT: replaced jingles can have different length, so if the callback function does not return a length, do not run special jingle code
 		--NOTE: the intention is that if a function does not return jinglelength, then the code runs like normal with no issues
-		if musicJingles[track] and (jinglelength or track == id) then --if we replaced this jingle and didn't provide length, don't run jingle-specific code
+		if not Game():IsGreedMode() and musicJingles[track] and (jinglelength or track == id) then --if we replaced this jingle and didn't provide length, don't run jingle-specific code
 			--Isaac.DebugString("running music jingle code for track "..tostring(track))
 			--Isaac.DebugString("jinglelength found to be "..tostring(jinglelength))
 			if jinglelength then
@@ -706,7 +706,7 @@ function musicPlay(track, track2)
 		--but if a boss over jingle replaces a stage track, it is not considered a jingle
 		--IMPORTANT: replaced jingles can have different length, so if the callback function does not return a length, do not run special jingle code
 		--NOTE: the intention is that if a function does not return jingleinfo, then the code runs like normal with no issues
-		if musicJingles[track] and (jingleinfo or track == id) then --if we replaced this jingle and didn't provide length, don't run jingle-specific code
+		if not Game():IsGreedMode() and musicJingles[track] and (jingleinfo or track == id) then --if we replaced this jingle and didn't provide length, don't run jingle-specific code
 			--Isaac.DebugString("running music jingle code for track "..tostring(track))
 			--Isaac.DebugString("jingleinfo found to be "..tostring(jingleinfo))
 			if jingleinfo then

--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -932,7 +932,7 @@ MusicModCallback:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
 		--NOTE: moved treasure/sound jingle initalization to musicPlay
 		
 		--moved from getMusicTrack to here so we can use musicPlay instead of musicCrossfade
-		if room:GetType() == RoomType.ROOM_TREASURE and room:IsFirstVisit() and (Game():IsGreedMode() or Game():GetLevel():GetStage() ~= LevelStage.STAGE4_3) then
+		if room:GetType() == RoomType.ROOM_TREASURE and room:IsFirstVisit() and (Game():IsGreedMode() or Game():GetLevel():GetStage() ~= LevelStage.STAGE4_3) and not modSaveData["inmirroredworld"] then
 			local rng = math.random(0,3)
 			local treasurejingle
 			if rng == 0 then

--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -911,7 +911,7 @@ MusicModCallback:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
 			end
 			
 			--NOTE: the room:IsClear() check handles back-to-back Bosses (i.e. XL floors)
-			if (roomtype == (RoomType.ROOM_SECRET_EXIT or 27) or roomtype == RoomType.ROOM_BOSS) and room:IsClear() and (musicJingles[Music.MUSIC_JINGLE_BOSS_OVER]["timeleft"] > 0 or musicJingles[Music.MUSIC_JINGLE_BOSS_OVER2]["timeleft"] > 0 or musicJingles[Music.MUSIC_JINGLE_BOSS_OVER3]["timeleft"] > 0) then
+			if (roomtype == (RoomType.ROOM_SECRET_EXIT or 27) or (roomtype == RoomType.ROOM_BOSS and room:IsClear())) and (musicJingles[Music.MUSIC_JINGLE_BOSS_OVER]["timeleft"] > 0 or musicJingles[Music.MUSIC_JINGLE_BOSS_OVER2]["timeleft"] > 0 or musicJingles[Music.MUSIC_JINGLE_BOSS_OVER3]["timeleft"] > 0) then
 				--Isaac.DebugString("skipping crossfade for Boss Room or Secret Exit Room")
 				skipCrossfade = true
 			else


### PR DESCRIPTION
-Built code for Music Jingles. In vanilla Repentance, the boss over jingle continues playing if you enter the Secret Exit room; and Mother's Shadow Intro keeps playing if you exit the Knife Piece 2 room. The musicJingles table allows us to mimic this. The modifications to musicCrossfade and musicPlay are designed to NOT break anybody's existing code.
-Built code for Sound Jingles. These are tracks that play on top of the quieted main track in vanilla Repentance (treasure, secret room, and strange door jingles). We replace them with an equivalent sound effect if we can. Again, the modifications are designed to NOT break existing code.
-If users of this mod want the tracks returned by their callback functions to have these musicJingle or soundJingle properties in-game, they must return a third value from their function which is the length of the jingle in total MC_POST_RENDER calls for musicJingles, and the custom sound ID for soundJingles.
-The lengths given for the musicJingles are rough and are subject to change. I tried to mimic vanilla lengths. The Mod Docs say that MC_POST_RENDER is called 60 times per second, but it was only about 48 per second on my computer. I really hope this is not machine-dependent.
-Finally, I leveraged the musicJingle code to improve the Game Start jingle logic. Now, the music still starts even if we pause on frame zero.