### PR TITLE
fix X-Ray Vision interaction with Ultra Secret

### DIFF
--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -1325,7 +1325,7 @@ MusicModCallback:AddCallback(ModCallbacks.MC_POST_RENDER, function()
 						local player = Isaac.GetPlayer()
 						local icanseeforever = level:GetCanSeeEverything()
 						local xrayvision = player:HasCollectible(CollectibleType.COLLECTIBLE_XRAY_VISION)
-						if not icanseeforever and not xrayvision then
+						if (not icanseeforever and not xrayvision) or door.TargetRoomType == RoomType.ROOM_ULTRASECRET then
 							musicPlay(Music.MUSIC_JINGLE_SECRETROOM_FIND, getMusicTrack())
 						end
 					end


### PR DESCRIPTION
In vanilla Repentance, the I Can See Forever Pill and X-Ray Vision item don't prevent the Ultra Secret Rooms from playing the Secret Room jingle