### PR TITLE
fixed issue #37 and issue #43

### DIFF
--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -349,9 +349,6 @@ local weakmusicmgr = {}
 setmetatable(weakmusicmgr, weakmusicmgrfuncs)
 setmetatable(weakmusicmgrfuncs, overridemusicmgrfuncs)
 
---it seems that if this code runs on game start, it only looks at save file 1
---it will look at the correct save file after enabling the mod from the Mod menu of a particular save file
---nonetheless, I think we should load this info again upon starting or continuing a run
 function MMC.ResetSave()
 	modSaveData["inmirrorroom"] = false
 	modSaveData["inmirroredworld"] = false
@@ -373,6 +370,11 @@ function MMC.LoadSave()
 		else
 			modSaveData["usernolayers"] = false
 		end
+		
+		--make sure we have values for non-boolean data
+		if modSaveData["darkhome"] == nil then modSaveData["darkhome"] = 0 end
+		if modSaveData["secretjingles"] == nil then modSaveData["secretjingles"] = {} end
+		if modSaveData["railbuttons"] == nil then modSaveData["railbuttons"] = {} end
 	end)
 	if not success then
 		MMC.ResetSave()

--- a/scripts/mmc/repentance.lua
+++ b/scripts/mmc/repentance.lua
@@ -1284,9 +1284,16 @@ MusicModCallback:AddCallback(ModCallbacks.MC_POST_RENDER, function()
 						satanfightstage = 2
 					end
 				elseif room:GetBossID() == 55 then
-					if Isaac.GetPlayer(0).Position.Y < 540 and satanfightstage == 0 and room:GetFrameCount() > 10 then
-						musicCrossfade(Music.MUSIC_SATAN_BOSS)
-						satanfightstage = 3
+					if satanfightstage == 0 and room:GetFrameCount() > 10 then
+						local playertable = Isaac.FindByType(EntityType.ENTITY_PLAYER,0) --variant 0 is true players, i.e. not co-op babies
+						for i,entity in pairs(playertable) do
+							local tempPlayer = entity:ToPlayer()
+							if tempPlayer and tempPlayer.Position.Y < 540 then
+								musicCrossfade(Music.MUSIC_SATAN_BOSS)
+								satanfightstage = 3
+								break
+							end
+						end
 					end
 				else
 					satanfightstage = 0
@@ -1398,9 +1405,13 @@ MusicModCallback:AddCallback(ModCallbacks.MC_POST_RENDER, function()
 				if door.State == DoorState.STATE_OPEN and (doorprevstates[i] == DoorState.STATE_CLOSED or door.TargetRoomType == RoomType.ROOM_ULTRASECRET) then
 					if Game():GetLevel():GetRoomByIdx(door.TargetRoomIndex).VisitedCount == 0 and not modSaveData["secretjingles"][tostring(door.TargetRoomIndex)] then
 						modSaveData["secretjingles"][tostring(door.TargetRoomIndex)] = true
-						local player = Isaac.GetPlayer()
 						local icanseeforever = level:GetCanSeeEverything()
-						local xrayvision = player:HasCollectible(CollectibleType.COLLECTIBLE_XRAY_VISION)
+						local xrayvision = false
+						local playertable = Isaac.FindByType(EntityType.ENTITY_PLAYER,0) --variant 0 is true players, i.e. not co-op babies
+						for i,entity in pairs(playertable) do
+							local tempPlayer = entity:ToPlayer()
+							xrayvision = xrayvision or (tempPlayer and tempPlayer:HasCollectible(CollectibleType.COLLECTIBLE_XRAY_VISION))
+						end
 						if (not icanseeforever and not xrayvision) or door.TargetRoomType == RoomType.ROOM_ULTRASECRET then
 							musicPlay(Music.MUSIC_JINGLE_SECRETROOM_FIND, getMusicTrack())
 						end


### PR DESCRIPTION
For data loading: if we add a non-boolean modSaveData variable to the mod following this pattern, and the mod updates while someone is in the middle of a run and taking a break, they will have the default value for that new variable upon continuing the run.
I also removed some old comments that were no longer relevant.